### PR TITLE
Aws spot instance sizing

### DIFF
--- a/doodad/mode.py
+++ b/doodad/mode.py
@@ -356,7 +356,6 @@ class EC2Mode(LaunchMode):
             print('Adding block device mappings')
             instance_args['BlockDeviceMappings'] = [dict(
                 DeviceName='/dev/sda1',
-                NoDevice='/dev/sda1',
                 VirtualName='ephemeral0',
                 Ebs=dict(
                     DeleteOnTermination=True,


### PR DESCRIPTION
This PR adds instance sizing to spot requests, in addition to having a few of your commits from the base fork (I think maybe because I pulled from the original Doodad?).  This is done through the [Block Device Mapping](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications-blockdevicemappings.html) API by overloading `/dev/sda1` with a new device generated from a given snapshot ID.  

Each AMI has an associated snapshot, so you can find this ID just by inspecting the AMI in the EC2 console, although it may also be possible to do this automatically using `boto3`.  Thus this PR changes the launcher interface to accept an optional `volume_size` and `snapshot_id` parameter, where both are required to modify the `BlockDeviceMappings.`